### PR TITLE
Fix withdraw with zap to WTLOS

### DIFF
--- a/src/features/vault/components/PoolDetails/WithdrawSection/WithdrawSection.js
+++ b/src/features/vault/components/PoolDetails/WithdrawSection/WithdrawSection.js
@@ -67,7 +67,7 @@ const WithdrawSection = ({ pool, index, sharesBalance }) => {
     ];
 
     if (pool.zap) {
-      const pairTokens = pool.zap.tokens.filter(t => t.symbol !== nativeCoin.wrappedSymbol);
+      const pairTokens = pool.zap.tokens;
       if (pairTokens.length) {
         outputs.push(
           {


### PR DESCRIPTION
There was an incorrect index for the zap-swap on withdraw before.
Tested with direct-to-ETH-withdraw in the WTLOS-WETH LP pair and
it worked.

To repro- try to withdraw to any single asset